### PR TITLE
Align lid monitor script with Hyprland defaults

### DIFF
--- a/XPSnixos/configuration.nix
+++ b/XPSnixos/configuration.nix
@@ -185,7 +185,7 @@
       if [[ "$LID_STATE" == "closed" && "$EXTERNAL" -gt 0 ]]; then
         hyprctl keyword monitor "eDP-1,disable"
       elif [[ "$LID_STATE" == "open" ]]; then
-        hyprctl keyword monitor "eDP-1,preferred,auto,1"
+        hyprctl keyword monitor "eDP-1,preferred,auto-left,1"
       fi
     '';
     wantedBy = ["hyprland-session.target"];

--- a/XPSnixos/configuration.nix
+++ b/XPSnixos/configuration.nix
@@ -188,7 +188,7 @@
         hyprctl keyword monitor "eDP-1,preferred,auto-left,1"
       fi
     '';
-    wantedBy = ["tray.target"];
+    wantedBy = ["hyprland-session.target"];
     serviceConfig = {
       Type = "oneshot";
     };

--- a/XPSnixos/configuration.nix
+++ b/XPSnixos/configuration.nix
@@ -185,7 +185,7 @@
       if [[ "$LID_STATE" == "closed" && "$EXTERNAL" -gt 0 ]]; then
         hyprctl keyword monitor "eDP-1,disable"
       elif [[ "$LID_STATE" == "open" ]]; then
-        hyprctl keyword monitor "eDP-1,preferred,auto-left,1"
+        hyprctl keyword monitor "eDP-1,preferred,auto,1"
       fi
     '';
     wantedBy = ["hyprland-session.target"];

--- a/XPSnixos/programs/hyprland.nix
+++ b/XPSnixos/programs/hyprland.nix
@@ -28,6 +28,7 @@
         "hacompanion"
         "owncloud"
         "bash /home/lorev/lid-monitor.sh"
+        "systemctl --user start lid-monitor.service"
       ];
       monitor = [
         "eDP-1,preferred,auto,1"


### PR DESCRIPTION
## Summary
- revert the Hyprland monitor configuration so the internal panel uses automatic positioning again

## Testing
- not run (nixos-rebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fcda3c4cd0832ba69512d3964b6cbe